### PR TITLE
feat: Add version control

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "srcup"
-version = "0.4.4"
+version = "0.4.5"
 description = ""
 authors = ["Tony Rocco Valentine <tvalentine@dedaub.com>", "Ilias Tsatiris <ilias@dedaub.com>"]
 readme = "README.md"

--- a/srcup/cli.py
+++ b/srcup/cli.py
@@ -50,10 +50,9 @@ def single(
 
     latest_app_version = asyncio.run(get_latest_app_version())
     if not latest_app_version:
-        print("Error: Failed to retrieve the latest version of the app")
-        return
+        print("Warning: Failed to retrieve the latest available version of the app")
 
-    if version.parse(app_version) < version.parse(latest_app_version):
+    elif version.parse(app_version) < version.parse(latest_app_version):
         print(f'Warning: A new version is available ({latest_app_version})\n')
         print(f'Please, update the app to continue:')
         print(f'  For pipx installation run:      pipx upgrade srcup')

--- a/srcup/utils.py
+++ b/srcup/utils.py
@@ -1,11 +1,13 @@
 from pathlib import Path
+from typer import Exit
 
-import aiohttp
-import dotenv
 import re
+import importlib.metadata
+import dotenv
+import aiohttp
 
 CONFIG_PATH = Path.home() / ".config" / "dedaub"
-
+__version__ = importlib.metadata.version('srcup')
 
 def create_config_dir():
     CONFIG_PATH.mkdir(parents=True, exist_ok=True)
@@ -13,6 +15,12 @@ def create_config_dir():
 
 def load_envfile():
     dotenv.load_dotenv(CONFIG_PATH / "credentials")
+
+
+def version_callback(show_version: bool):
+    if show_version:
+        print(__version__)
+        raise Exit()
 
 
 async def get_latest_app_version() -> str:
@@ -26,7 +34,6 @@ async def get_latest_app_version() -> str:
 
         if req.status == 200:
             data = await req.json()
-            version = data[0]['name']
-            return re.sub('[^0-9.]', '', version)
-        else:
-            return ''
+            if data:
+                return re.sub('[^0-9.]', '', data[0]['name'])
+        return ''

--- a/srcup/utils.py
+++ b/srcup/utils.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
+import aiohttp
 import dotenv
+import re
 
 CONFIG_PATH = Path.home() / ".config" / "dedaub"
 
@@ -11,3 +13,21 @@ def create_config_dir():
 
 def load_envfile():
     dotenv.load_dotenv(CONFIG_PATH / "credentials")
+
+
+async def get_latest_app_version() -> str:
+
+    async with aiohttp.ClientSession(
+        headers={'Accept': 'application/vnd.github.v3+json'}, json_serialize=lambda x: x.json()
+    ) as session:
+        url = 'https://api.github.com/repos/Dedaub/srcup/tags'
+
+        req = await session.get(url=url)
+
+        data = await req.json()
+        version = data[0]['name']
+
+        if req.status == 200:
+            return re.sub('[^0-9.]', '', version)
+        else:
+            return ''

--- a/srcup/utils.py
+++ b/srcup/utils.py
@@ -24,10 +24,9 @@ async def get_latest_app_version() -> str:
 
         req = await session.get(url=url)
 
-        data = await req.json()
-        version = data[0]['name']
-
         if req.status == 200:
+            data = await req.json()
+            version = data[0]['name']
             return re.sub('[^0-9.]', '', version)
         else:
             return ''


### PR DESCRIPTION
### Changes
1. Add support for `--version` and `-v` options to display the current version of the app
2. Add version control so that when a new version is uploaded, prevent the apps from running and prompt the users to update the app before proceeding
3. Allow the app to run without the required `TARGET` argument only when specific flags are enabled (i.e. `-v`)

### Requirements
1. You need to create a new tag for the desired versions
    - For example, when pushing version `0.4.3` you should create the tag `v0.4.3`
    - This can be done for each uploaded version or for crucial versions that contain significant changes or important bug fixes

2. The tags don't need to be annotated. You can use lightweight tags. 
The commands to create a tag at the latest commit are:
    - `git tag v0.4.3`
    - `git push origin v0.4.3`

3. To delete a tag run:
    - `git tag -d v0.4.3`
    - `git push origin :refs/tags/v0.4.3`

### Implementation
- The idea is that we get the latest available version using the Github API to access the metadata of the `srcup` repo. The repo is public, so no further authorization is needed to get that information

- We get the current version of the installed app and we compare the two versions allowing any version greater than the latest tag to be used
    - This allows us to not block the app on every update, but when an important change is published and we want all the users to upgrade before proceeding, then we can bump the tag version as well and enforce them to update